### PR TITLE
refactor: improve error handling consistency across commands

### DIFF
--- a/src/Commands/AddTask.hs
+++ b/src/Commands/AddTask.hs
@@ -5,6 +5,7 @@ module Commands.AddTask (addTaskCommand, addNewTask) where
 import Brick (get, modify, suspendAndResume)
 import Brick.BChan (writeBChan)
 import Commands.Command (Command (..), TuiBinding (..))
+import Commands.ErrorDialog (showError)
 import Control.Lens
 import Control.Monad.IO.Class (liftIO)
 import qualified Core.Operations as Ops
@@ -85,7 +86,7 @@ addNewTask = Helpers.saveForUndo $ do
   ctx <- get
   let fp = view (config . inboxFile) ctx
   case preview (fileLens fp) ctx of
-    Nothing -> return ()
+    Nothing -> showError $ "Inbox file not found: " <> T.pack fp <> "\n\nPlease check your configuration and ensure the inbox file exists."
     Just tf -> do
       now <- liftIO getZonedTime
       let createdStr = T.pack $ "[" ++ formatTime defaultTimeLocale orgDayTimeFormat now ++ "]"

--- a/src/Commands/Edit.hs
+++ b/src/Commands/Edit.hs
@@ -75,6 +75,4 @@ editSelectedTaskInEditor = Helpers.saveForUndo $ do
             ParserFailure e -> do
               _ <- writeBChan (view (appState . eventChannel) ctx) $ Error (e ++ " at " ++ show (line l) ++ ":" ++ show (column l))
               return ctx
-    _ -> do
-      showError "No task selected. Please select a task to edit."
-      return ctx
+    _ -> showError "No task selected. Please select a task to edit."

--- a/src/Commands/Edit.hs
+++ b/src/Commands/Edit.hs
@@ -5,6 +5,7 @@ module Commands.Edit (editTaskCommand, editSelectedTaskInEditor) where
 import Brick (get, modify, suspendAndResume)
 import Brick.BChan (writeBChan)
 import Commands.Command (Command (..), TuiBinding (..))
+import Commands.ErrorDialog (showError)
 import Control.Lens
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
@@ -74,4 +75,6 @@ editSelectedTaskInEditor = Helpers.saveForUndo $ do
             ParserFailure e -> do
               _ <- writeBChan (view (appState . eventChannel) ctx) $ Error (e ++ " at " ++ show (line l) ++ ":" ++ show (column l))
               return ctx
-    _ -> return ()
+    _ -> do
+      showError "No task selected. Please select a task to edit."
+      return ctx

--- a/src/Commands/ErrorDialog.hs
+++ b/src/Commands/ErrorDialog.hs
@@ -1,12 +1,21 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Commands.ErrorDialog where
+module Commands.ErrorDialog
+  ( errorDialogQuitCommand,
+    errorDialogAcceptCommand,
+    showError,
+  )
+where
 
 import Brick (modify)
+import Brick.Widgets.Dialog (dialog)
+import Brick.Widgets.Core (str)
 import Commands.Command (Command (..), TuiBinding (..))
+import Control.Lens (set)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Set as Set
+import qualified Data.Text as T
 -- For proceedInErrorDialog
 
 import Graphics.Vty (Key (KEsc))
@@ -17,8 +26,12 @@ import qualified Tui.Contexts as Ctx
 import Tui.Keybindings
 import qualified Tui.Keybindings as KB
 import Tui.Types
-  ( KeyEvent (..),
+  ( ErrorDialog (..),
+    GlobalAppState,
+    KeyEvent (..),
     KeyPress (..),
+    appState,
+    errorDialog,
   )
 import Writer.Writer (Writer)
 
@@ -61,3 +74,18 @@ errorDialogAcceptCommand =
       cmdCli = Nothing,
       cmdApi = Nothing
     }
+
+-- | Show an error dialog with the given message
+-- This is a helper function for consistent error handling across commands
+showError :: T.Text -> GlobalAppState a
+showError msg = do
+  let dlg =
+        ErrorDialog
+          { _edDialog =
+              dialog
+                (Just $ str "Error")
+                Nothing
+                50,
+            _edMessage = T.unpack msg
+          }
+  modify $ set (appState . errorDialog) (Just dlg)

--- a/src/Commands/OpenUrl.hs
+++ b/src/Commands/OpenUrl.hs
@@ -6,6 +6,7 @@ module Commands.OpenUrl (openUrlCommand, openTaskUrl, extractFirstUrl, openUrlIn
 import Brick (get)
 import Brick.BChan (writeBChan)
 import Commands.Command (Command (..), TuiBinding (..))
+import Commands.ErrorDialog (showError)
 import Control.Applicative ((<|>))
 import Control.Exception (IOException, catch)
 import Control.Lens
@@ -68,8 +69,8 @@ openTaskUrl = do
           case result of
             Left err -> liftIO $ writeBChan (view (appState . eventChannel) ctx) $ Error err
             Right () -> return ()
-        Nothing -> return ()
-    Nothing -> return ()
+        Nothing -> showError "No URL found in task.\n\nURLs can be in the task title or description.\nSupported formats:\n- Plain: http://example.com\n- Org-mode: [[http://example.com]]"
+    Nothing -> showError "No task selected. Please select a task first."
 
 -- | Extract the first URL from text (supports org-mode [[url]] format and plain URLs)
 extractFirstUrl :: T.Text -> Maybe T.Text

--- a/src/Commands/Projects.hs
+++ b/src/Commands/Projects.hs
@@ -4,6 +4,7 @@ module Commands.Projects (goToProjectsCommand, goToProjectView, saveForJump, sho
 
 import Brick (get, modify)
 import Commands.Command (Command (..), TuiBinding (..))
+import Commands.ErrorDialog (showError)
 import Control.Lens
 import Control.Monad (when)
 import qualified Core.Operations as Ops
@@ -75,7 +76,7 @@ goToProjectView = do
   let fs = view fileStateLens ctx
       maybeCurrentPtr = view currentTaskPtr ctx
   case maybeCurrentPtr of
-    Nothing -> return ()
+    Nothing -> showError "No task selected. Please select a task first."
     Just currentPtr -> do
       let maybeProjectPtr = Ops.findProjectForTask currentPtr fs
           currentTask = preview (taskBy currentPtr) fs
@@ -89,7 +90,7 @@ goToProjectView = do
             Just task
               | Ops.isProjectTask task ->
                   showProjectView currentPtr fs ctx
-            _ -> return () -- Do nothing if task is neither PROJECT nor has parent PROJECT
+            _ -> showError "Current task is not a project and has no parent project.\n\nTo use project view, select a task that:\n- Has TODO state 'PROJECT', or\n- Is a subtask of a PROJECT task"
 
 -- | Helper function to show project view for a given project pointer
 showProjectView :: TaskPointer -> FileState Task -> AppContext Task -> GlobalAppState Task

--- a/src/Commands/Refile.hs
+++ b/src/Commands/Refile.hs
@@ -4,6 +4,7 @@ module Commands.Refile (refileCommand, openRefileDialog) where
 
 import Brick (get, modify)
 import Commands.Command (Command (..), TuiBinding (..))
+import Commands.ErrorDialog (showError)
 import Control.Lens
 import qualified Core.Operations as Ops
 import Data.List.NonEmpty (NonEmpty (..))
@@ -52,7 +53,7 @@ openRefileDialog = do
   let fs = view fileStateLens ctx
       allProjects = Ops.getAllProjects fs
   case allProjects of
-    [] -> return () -- No projects found
+    [] -> showError "No projects found in your task files.\n\nTo refile a task, you need at least one task with TODO state 'PROJECT'."
     _ -> do
       let dialog =
             RefileDialog


### PR DESCRIPTION
- Add showError helper in Commands/ErrorDialog.hs for consistent error dialogs
- Update Commands/Projects.hs: show errors when no task selected or task is not a project
- Update Commands/Edit.hs: show error when no task is selected
- Update Commands/Refile.hs: show error when no projects are found
- Update Commands/AddTask.hs: show error when inbox file not found
- Update Commands/OpenUrl.hs: show errors when no task selected or no URL found

All commands now provide user-friendly error messages instead of silently failing, improving the overall user experience.